### PR TITLE
Hotfix for IndexOutOfBoundsException

### DIFF
--- a/src/main/scala/codechicken/multipart/TileMultipart.scala
+++ b/src/main/scala/codechicken/multipart/TileMultipart.scala
@@ -524,7 +524,7 @@ trait TileMultipartClient extends TileMultipart {
     def renderDamage(pos: Vector3, texture: TextureAtlasSprite, ccrs: CCRenderState) {
         Minecraft.getMinecraft.objectMouseOver match {
             case hit: PartRayTraceResult =>
-                partList(hit.partIndex).renderBreaking(pos, texture, ccrs)
+                partList.lift(hit.partIndex).foreach(_.renderBreaking(pos, texture, ccrs))
             case _ =>
         }
     }


### PR DESCRIPTION
The following exception always crashed the client when I was playing around with ProjectRed Frames:

java.lang.IndexOutOfBoundsException: 3
	at scala.collection.LinearSeqOptimized$class.apply(LinearSeqOptimized.scala:51)
	at scala.collection.immutable.List.apply(List.scala:83)
	at codechicken.multipart.TileMultipartClient$class.renderDamage(TileMultipart.scala:527)
	at TileMultipart_cmp$$4.renderDamage(Unknown Source)
	at codechicken.multipart.MultipartRenderer$.handleRenderBlockDamage(MultipartRenderer.scala:108)
	at codechicken.lib.render.block.BlockRenderingRegistry.renderBlockDamage(BlockRenderingRegistry.java:84)
	at codechicken.lib.render.block.CCBlockRendererDispatcher.func_175020_a(CCBlockRendererDispatcher.java:37)
	at mrtjp.projectred.relocation.MovingBlockRenderDispatcher.func_175020_a(renders.scala:306)
	at com.elytradev.architecture.client.render.CustomBlockDispatcher.func_175020_a(CustomBlockDispatcher.java:89)
	at net.minecraft.client.renderer.RenderGlobal.func_174981_a(RenderGlobal.java:1937)
	at net.minecraft.client.renderer.EntityRenderer.func_175068_a(EntityRenderer.java:1373)
	at net.minecraft.client.renderer.EntityRenderer.func_78471_a(EntityRenderer.java:1259)
	at net.minecraft.client.renderer.EntityRenderer.func_181560_a(EntityRenderer.java:1062)
	at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1117)
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:397)
	at net.minecraft.client.main.Main.main(SourceFile:123)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)