### PR TITLE
Update README with updated URLs for stable/dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ ForgeMultipart
 An API for dynamically handling different functional parts in the one block space.
 
 Requirements:
-* The latest version of CCL (files.minecraftforge.net/CodeChickenLib/)
+* The latest version of [CodeChicken Lib (CCL)](https://minecraft.curseforge.com/projects/codechicken-lib-1-8)
 * Forge
 * A scala compatible IDE and project (For eclipse, download the scala eclipse plugin and right click on the project -> Add Scala Nature)
 
 If you only want to use the API and not modify it:
- * Download the latest dev version from files.minecraftforge.net/ForgeMultipart/
+ * Download the latest stable version from [Forge Multipart CBE on Curseforge](https://minecraft.curseforge.com/projects/forge-multipart-cbe) or latest development version from [Chicken Bones Mods](http://chickenbones.net/Pages/links.html)
  * Download the latest dev version of CCL.
  * Place both mods in your /libs/ folder and link them as libraries in your IDE.
 


### PR DESCRIPTION
The URLs provided in this readme link to sites that are a few years out of date.  Put in the URLs that appear to be the primary sources to go to when looking for new stable/dev versions of ForgeMultipart.