### PR TITLE
Fix world lag when SavedMultipart cannot be loaded

### DIFF
--- a/src/main/scala/codechicken/multipart/TileMultipart.scala
+++ b/src/main/scala/codechicken/multipart/TileMultipart.scala
@@ -686,6 +686,8 @@ object TileMultipart {
      * Creates this tile from an NBT tag
      */
     def createFromNBT(tag: NBTTagCompound): TileMultipart = {
+        if (tag == null) return null
+
         val partList = tag.getTagList("parts", 10)
         val parts = ListBuffer[TMultiPart]()
 


### PR DESCRIPTION
In the issue #40 I've written that there was a massive lag caused by the fix you provided. I figured out what was causing it.

The issue was occurring only when a saved multipart tile entity couldn't be loaded properly. Take look at the  [TileNBTContainer.update](https://github.com/TheCBProject/ForgeMultipart/blob/8d944a5ed034f1fb6ea2c661b6a544de3697d6ad/src/main/scala/codechicken/multipart/handler/MultipartSaveLoad.scala#L59-L85) method: when the variable `newTile` is `null`, tile entity should removed from world. But somehow it isn't (I have no idea why). The problem is that none of the conditions (`failed` and `loaded`) is changed afterwards and a tile entity is being removed 20 times per second. Note that every time the `World.removeTileEntity` method is called (even if that tile doesn't exist anymore) container block's neighbors get notified. Multiply this by a large amount of corrupted multipart tile entities (in my case after update 1.10 to 1.12) and you've got a lag.